### PR TITLE
Migrate the build on redhat ubi-minimal 8, QA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 COMPILER_TARGET ?= $(COMPILER_TARGET_ARCH)-redhat-linux
 SYSROOT_PATH ?= /
 
-export CC = clang-16
+export CC = clang
 export COMPILER_TARGET
 export CGO_CFLAGS = --sysroot=/usr/sysroot --target=$(COMPILER_TARGET)
 export CGO_ENABLED = 1
@@ -66,7 +66,7 @@ clean:
 	@$(MAKE) -s -C support/ebpf clean
 	@rm -f support/*.test
 	@chmod -Rf u+w go/ || true
-	@rm -rf go .cache
+	@rm -rf go/pkg go/.cache .cache
 
 generate:
 	go generate ./...
@@ -77,22 +77,40 @@ ebpf:
 ebpf-profiler: generate ebpf
 	go build $(GO_FLAGS) -tags $(GO_TAGS)
 
+PROTOC_GEN_VERSION = "v1.31.0"
+PROTOC_GRPC_VERSION = "v1.3.0"
 GOLANGCI_LINT_VERSION = "v1.60.1"
+PORTO_VERSION = "v0.6.0"
+
+install-grpc-deps:
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_VERSION)
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GRPC_VERSION)
+
+install-ci-deps:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	go install github.com/jcchavezs/porto/cmd/porto@$(PORTO_VERSION)
+
+install-go-deps: install-grpc-deps install-ci-deps
+
+clean-go-deps: clean
+	@rm go/bin/protoc*
+	@rm go/bin/porto*
+	@rm go/bin/golang*
+
 lint: generate vanity-import-check
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) version
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
+	golangci-lint version
+	golangci-lint run
 
 linter-version:
-	@echo $(GOLANGCI_LINT_VERSION)
+	@echo golangci-lint version: $(GOLANGCI_LINT_VERSION)
+	@echo porto version: $(PORTO_VERSION)
 
 .PHONY: vanity-import-check
 vanity-import-check:
-	@go install github.com/jcchavezs/porto/cmd/porto@latest
 	@porto --include-internal -l . || ( echo "(run: make vanity-import-fix)"; exit 1 )
 
 .PHONY: vanity-import-fix
 vanity-import-fix: $(PORTO)
-	@go install github.com/jcchavezs/porto/cmd/porto@latest
 	@porto --include-internal -w .
 
 test: generate ebpf test-deps
@@ -119,7 +137,7 @@ integration-test-binaries: generate ebpf
 	)
 
 docker-image:
-	docker build -t profiling-agent -f Dockerfile .
+	docker build -t profiling-agent -f docker-image/Dockerfile .
 
 agent:
 	docker run -v "$$PWD":/agent -v $(SYSROOT_PATH):/usr/sysroot -it --rm --user $(shell id -u):$(shell id -g) profiling-agent \

--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -1,31 +1,37 @@
-FROM debian:testing
+FROM registry.redhat.io/ubi8/ubi-minimal:latest
 
-WORKDIR /agent
+WORKDIR /agent-go
 
-RUN apt-get update -y && \
-    apt-get dist-upgrade -y && \
-    apt-get install -y clang-16 git lld-16 make pkgconf unzip wget && \
-    apt-get clean autoclean && \
-    apt-get autoremove --yes
+RUN microdnf update -y \
+    && microdnf install -y llvm-toolset git unzip wget \
+    && microdnf install -y tar gzip unzip findutils lld
+
+RUN microdnf clean all -y
 
 COPY go.mod /tmp/go.mod
 # Extract Go version from go.mod
 RUN GO_VERSION=$(grep -oPm1 '^go \K([[:digit:].]+)' /tmp/go.mod) && \
     GOARCH=$(uname -m) && if [ "$GOARCH" = "x86_64" ]; then GOARCH=amd64; elif [ "$GOARCH" = "aarch64" ]; then GOARCH=arm64; fi && \
-    wget -qO- https://golang.org/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz | tar -C /usr/local -xz
+    wget https://golang.org/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz && \
+    tar -C /usr/local -xvzf ./go${GO_VERSION}.linux-${GOARCH}.tar.gz && \
+    rm -rf ./go${GO_VERSION}.linux-${GOARCH}.tar.gz
 
 # Set Go environment variables
-ENV GOPATH="/agent/go"
-ENV GOCACHE="/agent/.cache"
+ENV GOPATH="/agent-go"
+ENV GOCACHE="$GOPATH/.cache"
+ENV GOBIN="$GOPATH/bin"
+# not addin GOBIN on purpose, see entrypoint
 ENV PATH="/usr/local/go/bin:$PATH"
 
 # gRPC dependencies
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+RUN go install github.com/jcchavezs/porto/cmd/porto@v0.6.0
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 
 RUN                                                                                \
   PB_URL="https://github.com/protocolbuffers/protobuf/releases/download/v24.4/";   \
-  PB_FILE="protoc-24.4-linux-x86_64.zip";                                      \
+  PB_FILE="protoc-24.4-linux-x86_64.zip";                                          \
   INSTALL_DIR="/usr/local";                                                        \
                                                                                    \
   wget -q "$PB_URL/$PB_FILE"                                                       \
@@ -36,6 +42,10 @@ RUN                                                                             
     && rm "$PB_FILE"
 
 # Append to /etc/profile for login shells
-RUN echo 'export PATH="/usr/local/go/bin:$PATH"' >> /etc/profile
+RUN echo 'export PATH="$PATH"' >> /etc/profile
 
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+WORKDIR /agent
+
+COPY docker-image/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-image/entrypoint.sh
+++ b/docker-image/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+ORIG_GOPATH="/agent-go"
+
+NEW_GOPATH="/agent/go"
+GOPATH="$NEW_GOPATH"
+GOCACHE="$GOPATH/.cache"
+GOBIN="$GOPATH/bin"
+PATH="$PATH:$GOBIN"
+GOLANGCI_LINT_CACHE=$GOCACHE
+
+# Check if /agent/go exists, and create it if not
+if [ ! -d "${GOPATH}" ]; then
+  mkdir -p ${GOPATH}
+  mkdir -p ${GOBIN}
+fi
+
+cp --recursive $ORIG_GOPATH/bin/* $GOBIN
+
+export GOPATH
+export GOCACHE
+export GOBIN
+export PATH
+export GOLANGCI_LINT_CACHE
+
+# Run the actual command (e.g., bash or other processes)
+exec $@

--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -1,7 +1,7 @@
 SHELL ?= bash
-BPF_CLANG ?= clang-16
-BPF_LINK ?= llvm-link-16
-LLC ?= llc-16
+BPF_CLANG ?= clang
+BPF_LINK ?= llvm-link
+LLC ?= llc
 
 DEBUG_FLAGS = -DOPTI_DEBUG -g
 


### PR DESCRIPTION
# Reference
[Jira ticket](https://jsw.ibm.com/browse/INSTA-16822)

# WHAT

1. Migrate base image of the ebpf-profiler building image from `debian:testing` to `registry.redhat.io/ubi8/ubi-minimal:latest`
Attention: Clang version on this image is 18, not 16.

2. Refactor the files to build the ebpf-profiler building image to the directory `docker-image`
The docker image entrypoint moves to /agent/go/bin all the binaries needed by GO for the generation and linting

3. Makefile:  pin GO deps versions
Attention: pin porto version to "v0.6.0" (instead of latest). The latest version of porto requires GO 1.23.
4.  Makefile: fix the clean target.
5. Makefiles: substitute clang-16 with clang.
6. Makefile: remove the installation of GolangCi deps during linting.
7. Makefile: add targets for GO deps management

# WHY
1. Compliance
2-7: Fixes