### PR TITLE
[APPROVED] INSTA-16822: Build on ubuntu+clang17, fix cross-build, QA, v2

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -1,31 +1,48 @@
-FROM debian:testing
+ARG image=public.ecr.aws/ubuntu/ubuntu:22.04
 
-WORKDIR /agent
+FROM ${image}
 
-RUN apt-get update -y && \
-    apt-get dist-upgrade -y && \
-    apt-get install -y clang-16 git lld-16 make pkgconf unzip wget && \
-    apt-get clean autoclean && \
-    apt-get autoremove --yes
+WORKDIR /agent-go
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        gnupg2 \
+        software-properties-common \
+        wget \
+        git \
+        findutils \
+        unzip \
+        make
+
+RUN wget https://apt.llvm.org/llvm.sh \
+    && chmod +x llvm.sh \
+    && ./llvm.sh 17
 
 COPY go.mod /tmp/go.mod
 # Extract Go version from go.mod
 RUN GO_VERSION=$(grep -oPm1 '^go \K([[:digit:].]+)' /tmp/go.mod) && \
     GOARCH=$(uname -m) && if [ "$GOARCH" = "x86_64" ]; then GOARCH=amd64; elif [ "$GOARCH" = "aarch64" ]; then GOARCH=arm64; fi && \
-    wget -qO- https://golang.org/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz | tar -C /usr/local -xz
+    wget https://golang.org/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz && \
+    tar -C /usr/local -xvzf ./go${GO_VERSION}.linux-${GOARCH}.tar.gz && \
+    rm -rf ./go${GO_VERSION}.linux-${GOARCH}.tar.gz
 
 # Set Go environment variables
-ENV GOPATH="/agent/go"
-ENV GOCACHE="/agent/.cache"
+ENV GOPATH="/agent-go"
+ENV GOCACHE="$GOPATH/.cache"
+ENV GOBIN="$GOPATH/bin"
+# not addin GOBIN on purpose, see entrypoint
 ENV PATH="/usr/local/go/bin:$PATH"
 
 # gRPC dependencies
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+RUN go install github.com/jcchavezs/porto/cmd/porto@v0.6.0
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 
 RUN                                                                                \
   PB_URL="https://github.com/protocolbuffers/protobuf/releases/download/v24.4/";   \
-  PB_FILE="protoc-24.4-linux-x86_64.zip";                                      \
+  PB_FILE="protoc-24.4-linux-x86_64.zip";                                          \
   INSTALL_DIR="/usr/local";                                                        \
                                                                                    \
   wget -q "$PB_URL/$PB_FILE"                                                       \
@@ -36,6 +53,10 @@ RUN                                                                             
     && rm "$PB_FILE"
 
 # Append to /etc/profile for login shells
-RUN echo 'export PATH="/usr/local/go/bin:$PATH"' >> /etc/profile
+RUN echo 'export PATH="$PATH"' >> /etc/profile
 
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+WORKDIR /agent
+
+COPY docker-image/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-image/entrypoint.sh
+++ b/docker-image/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+ORIG_GOPATH="/agent-go"
+
+NEW_GOPATH="/agent/go"
+GOPATH="$NEW_GOPATH"
+GOCACHE="$GOPATH/.cache"
+GOBIN="$GOPATH/bin"
+PATH="$PATH:$GOBIN"
+GOLANGCI_LINT_CACHE=$GOCACHE
+
+# Check if /agent/go exists, and create it if not
+if [ ! -d "${GOPATH}" ]; then
+  mkdir -p ${GOPATH}
+  mkdir -p ${GOBIN}
+fi
+
+cp --recursive $ORIG_GOPATH/bin/* $GOBIN
+
+export GOPATH
+export GOCACHE
+export GOBIN
+export PATH
+export GOLANGCI_LINT_CACHE
+
+git config --global --add safe.directory /agent
+
+# Run the actual command (e.g., bash or other processes)
+exec $@

--- a/support/ebpf/Makefile
+++ b/support/ebpf/Makefile
@@ -1,7 +1,7 @@
 SHELL ?= bash
-BPF_CLANG ?= clang-16
-BPF_LINK ?= llvm-link-16
-LLC ?= llc-16
+BPF_CLANG ?= clang-17
+BPF_LINK ?= llvm-link-17
+LLC ?= llc-17
 
 DEBUG_FLAGS = -DOPTI_DEBUG -g
 

--- a/support/ebpf/print_instruction_count.sh
+++ b/support/ebpf/print_instruction_count.sh
@@ -7,9 +7,9 @@ export SHELLOPTS
 
 file="$1"
 
-OBJDUMP_CMD=llvm-objdump
+OBJDUMP_CMD=llvm-objdump-17
 if ! type -p "${OBJDUMP_CMD}"; then
-    OBJDUMP_CMD=llvm-objdump-16
+    OBJDUMP_CMD=llvm-objdump-17
 fi
 
 echo -e "\nInstruction counts for ${file}:\n"


### PR DESCRIPTION
# Reference
[Jira ticket](https://jsw.ibm.com/browse/INSTA-16822)
[Official APT LLVM Site](https://apt.llvm.org/)

# WHAT

[NEW] 1. Migrate base image of the ebpf-profiler building image from DockerHub `debian:testing` to AWS ubuntu:22.04 (do not use delivery.instana.io!).
**Attention**: Install Clang version 17 with the script in https://apt.llvm.org/ and not downloading a tar from Github Releases. This method is more stable.
2. Refactor the files to build the ebpf-profiler building image to the directory `docker-image`
The docker image entrypoint moves to /agent/go/bin all the binaries needed by GO for the generation and linting
3. Makefile:  pin GO deps versions
Attention: pin porto version to "v0.6.0" (instead of latest). The latest version of porto requires GO 1.23.
4. Makefile: fix the clean target.
[NEW]  5. Makefiles: substitute clang-16 with clang-17.
6. Makefile: remove the installation of GolangCi deps during linting.
7. Makefile: add targets for GO deps management
8. Makefile: Fix cross-compilation
Always use NATIVE_ARCH as GOARCH for go:generate. The previous approach may fail on systems that can not execute cross-compiled binaries on the build host (e.g. if an appropriate qemu binary is not installed).

# WHY
1. Compliance
2-8: Fixes

# NOTE
* This new PR is adding some good stuff on top of
https://github.com/instana/opentelemetry-ebpf-profiler/pull/9
Basically point 1 and point 5 of the "WHAT" list.

* 📌   This PR still needs review, but it is not meant to be merged: the patch was produced and added to https://github.ibm.com/instana/ebpf-profiler-cicd/pull/6. When this code is approved, the PR https://github.ibm.com/instana/ebpf-profiler-cicd/pull/6 will be merged and this PR will be closed.