### PR TITLE
INSTA-16822: Lint update toolchain: Bump golangci-lint to 1.63.4, install clang-format-17

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -38,7 +38,7 @@ ENV PATH="/usr/local/go/bin:$PATH"
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
 RUN go install github.com/jcchavezs/porto/cmd/porto@v0.6.0
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 
 RUN                                                                                \
   PB_URL="https://github.com/protocolbuffers/protobuf/releases/download/v24.4/";   \

--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update -y \
 
 RUN wget https://apt.llvm.org/llvm.sh \
     && chmod +x llvm.sh \
-    && ./llvm.sh 17
+    && ./llvm.sh 17 \
+    && apt install clang-format-17
 
 COPY go.mod /tmp/go.mod
 # Extract Go version from go.mod


### PR DESCRIPTION
# References
[Jira Ticket](https://jsw.ibm.com/browse/INSTA-16822)

# WHAT
docker image: pin golangci-lint to v1.63.4, install clang-format-17

# WHY
1: upgrade golangci-lint version according to upstream changes
[Bump golangci-lint to 1.63.4](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/commit/2698137c2c2be07da37858153b4ad6bb36a01eed)

# TESTING

## For the reviewer: general recommendations / observations
👀 Since we synched the downstream with the upstream, you don't need to patch the downstream in order to build and test.
You still need ebpf-profiler-cicd that *contains sysroot amazon baseline*
👀 Since synch_2025_01 we are using clang-format-17, and the linting show new errors.

## For the reviewer: how to perform complete regression testing, arch x86
Follow these steps to verify the correct behavior of [opentelemetry-ebpf-profiler](https://github.com/instana/opentelemetry-ebpf-profiler) after the application of this patch.

```
# remove old profiling-agent images
# 👀 This step sounds redundant, but it is very likely to be needed since docker-image is changing frequently
docker rmi -f #profiling_image_id # the id is the 3rd field in the output of docker images
# prune cached layers in docker builder
yes | docker builder prune --all
# create used alias in this test
alias gitworld='git fetch --all --prune'
mkdir OEP-VERIFY
cd OEP-VERIFY
ROOT=$(pwd)
# attention: clone ebpf-profiler-cicd in order to have sysroot baseline
git clone git@github.ibm.com:instana/ebpf-profiler-cicd.git
# attention: clone opentelemetry-ebpf-profiler
git clone git@github.com:instana/opentelemetry-ebpf-profiler.git
cd opentelemetry-ebpf-profiler

# 👀   pay attention to the variables!
SYSROOT_PATH="${ROOT}/ebpf-profiler-cicd/sysroot/linux-x86_64/amazon-linux-2.0.20241113.1/"
ls $SYSROOT_PATH must give:
lib  lib64  usr
# set SRC_DIR
SRC_DIR=$(pwd)
make docker-image # it will take a couple of minutes, we removed docker builder cache!
# Verify that the image `profiling-agent:latest` has been built
docker images|egrep -i profiling
# output must be something like:
profiling-agent                                                                latest    <image-id> About a minute ago   2.18GB
# Execute linting and tests inside the container
# Run the build image: this should log you inside the container
docker run --user "$(id -u):$(id -g)" -v "${SRC_DIR}:/agent" -v "${SYSROOT_PATH}":/usr/sysroot --name "profiling-agent-1" --rm -it profiling-agent /bin/bash
# Ignore the following messages:
# error: could not lock config file //.gitconfig: Permission denied
# groups: cannot find name for group ID 1000
# Run linting and testing on the building image
make lint # if you used this directory before, do make clean first
# output: a bunch of GO dependencies are installed
# note: this message is normal "golangci-lint has version v1.60.1 built with go1.22.2 from (unknown, modified: ?, mod sum: "h1:DRKNqNTQRLBJZ1il5u4fvgLQCjQc7QFs0DbhksJtVJE=") on (unknown)"

# 👀 Since from synch_2025_01 we are using clang-format-17, these errors now show up:
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/unbounded_executor.go:58:2: increment-decrement: should replace executor.activeGoroutines[startFrom] += 1 with executor.activeGoroutines[startFrom]++ (revive)
	executor.activeGoroutines[startFrom] += 1
	^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/unbounded_executor.go:72:4: increment-decrement: should replace executor.activeGoroutines[startFrom] -= 1 with executor.activeGoroutines[startFrom]-- (revive)
			executor.activeGoroutines[startFrom] -= 1
			^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/unbounded_executor_test.go:12:19: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
	executor.Go(func(ctx context.Context) {
	                 ^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/unbounded_executor_test.go:42:32: unused-parameter: parameter 'recovered' seems to be unused, consider removing or renaming it as _ (revive)
	concurrent.HandlePanic = func(recovered interface{}, funcName string) {
	                              ^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/unbounded_executor_test.go:52:16: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func willPanic(ctx context.Context) {
               ^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/go_above_19.go:1:1: File is not properly formatted (gofmt)
//+build go1.9
^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/log.go:4:1: File is not properly formatted (gofmt)
	"os"
^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/unbounded_executor.go:5:1: File is not properly formatted (gofmt)
	"fmt"
^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/unbounded_executor.go:15:2: S1038: should use ErrorLogger.Printf(...) instead of ErrorLogger.Println(fmt.Sprintf(...)) (gosimple)
	ErrorLogger.Println(fmt.Sprintf("%s panic: %v", funcName, recovered))
	^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/executor.go:6:73: `cancelled` is a misspelling of `canceled` (misspell)
// the goroutine should cancel itself if the context passed in has been cancelled
                                                                        ^
go/pkg/mod/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd/unbounded_executor.go:91:16: `cancelled` is a misspelling of `canceled` (misspell)
// Wait can be cancelled by the context passed in.
               ^
make: *** [Makefile:115: lint] Error 1                                                                                                                                                                    
```

The errors can be checked in the image:


![image](https://github.com/user-attachments/assets/1c27fabd-ef39-4897-bce0-4b468115e28b)


```
# troubleshooting: if the error `make: *** [Makefile:110: vanity-import-check] Error 1` appears, maybe you used this directory before for building - Solutions: execute `make clean` and re-run `make lint`
make test # it takes up to 2 minutes, be patient
# output: a bunch of tests is done
# if no errors are shown, it means the tests were successful
# note: you will see the following warning
# "tools/coredump/ebpfcode.go:45:1: warning: non-void function does not return a value [-Wreturn-type]"

# execute again make clean
# exit the build-image container

# Build the profiling agent
SYSROOT_PATH="${SYSROOT_PATH}" make agent
# output: the message "GOARCH=amd64 go generate ./..." and a bunch of make operations
# if no errors are shown, it means the build was successful.
# verify the existence and characteristic of ebpf-profiler file, with the following command:
file ebpf-profiler
# output must be something like: ebpf-profiler: ELF 64-bit LSB executable, x86-64, [etc..]
# check that this binary file was modified in the timestamp: `support/ebpf/tracer.ebpf.release.amd64`
git status
the output shows that the only "modified file" (it is actually a binary...) is `support/ebpf/tracer.ebpf.release.amd64`
```

## For the reviewer: how to perform complete regression testing, arch arm
Follow these steps to Cross-compile the ebpf agent for a different architecture:

```
📌  # Important: clean artifacts coming from previous test, with the following:
docker run --user "$(id -u):$(id -g)" -v "${SRC_DIR}:/agent" -v "${SYSROOT_PATH}":/usr/sysroot --name "profiling-agent-1" --rm -it profiling-agent /bin/bash
make clean
# exit the container

# reset SYSROOT_PATH:
# 👀 Pay attention to variables
SYSROOT_PATH="${ROOT}/ebpf-profiler-cicd/sysroot/linux-aarch64/amazon-linux-2.0.20241113.1/"
SYSROOT_PATH="${SYSROOT_PATH}" TARGET_ARCH=arm64 make agent  # it can takes up to 2 minutes, be patient

# verify the existence and characteristic of ebpf-profiler file, with the following command:
file ebpf-profiler
# output must be something like: ebpf-profiler: ELF 64-bit LSB pie executable, ARM aarch64 [etc...]
# verify the presence of support/ebpf/tracer.ebpf.release.arm64 and the recent timestamp
```