### PR TITLE
[INSTA-30557] Dockerfile: Install curl, musl-dev and export CC, CXX

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -5,20 +5,28 @@ FROM ${image}
 WORKDIR /agent-go
 
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
+    && apt-get install -y software-properties-common \
+    && apt update -y \
+    && add-apt-repository universe \
+    && apt-get install -y build-essential \
         ca-certificates \
         gnupg2 \
-        software-properties-common \
         wget \
         git \
         findutils \
         unzip \
-        make
+        make \
+        curl \
+        musl-dev \
+        cmake
 
-RUN wget https://apt.llvm.org/llvm.sh \
-    && chmod +x llvm.sh \
-    && ./llvm.sh 17 \
-    && apt install clang-format-17
+
+ENV CLANG_VERSION="17"
+ENV CXX=clang++-"$CLANG_VERSION"
+ENV CC=clang-"$CLANG_VERSION"
+RUN wget -O - https://apt.llvm.org/llvm.sh | bash -s ${CLANG_VERSION} \
+    && echo "export CXX=clang++-$CLANG_VERSION" >> /root/.bashrc \
+    && echo "export CC=clang-$CLANG_VERSION" >> /root/.bashrc
 
 COPY go.mod /tmp/go.mod
 # Extract Go version from go.mod
@@ -70,6 +78,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
 RUN echo 'export PATH="/usr/local/cargo/bin:$PATH"' >> /etc/profile     \
     && echo 'export CARGO_HOME="/usr/local/cargo"' >> /etc/profile      \
     && echo 'export RUSTUP_HOME="/usr/local/rustup"' >> /etc/profile
+
+ENV PATH="$PATH:/usr/local/cargo/bin"
 
 # Set mode bits
 RUN chmod -R a+w /usr/local/rustup      \

--- a/docker-image/entrypoint.sh
+++ b/docker-image/entrypoint.sh
@@ -22,6 +22,8 @@ export GOCACHE
 export GOBIN
 export PATH
 export GOLANGCI_LINT_CACHE
+export CC
+export CXX
 
 git config --global --add safe.directory /agent
 


### PR DESCRIPTION
**What**

1.  Install Packages : Make, muse-dev, cmake, curl
2. Export env variables.

**Why**
The upstream project has added Rust. To properly install and run Rust, the build docker requires some packages . Also, env variable like CC and CXX need to be available in the environment.   

Note: This effort is part of syncing to upstream.

**Test**
`make docker -image` and `make agent` succeeds after adding these changes to `sync_2025_02_wip (up commit 565a8fb)`.

```
root@BUbu1:~/instana-ebpf/opentelemetry-ebpf-profiler# make docker-image
docker build -t profiling-agent -f docker-image/Dockerfile .
[+] Building 0.9s (24/24) FINISHED                                                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                0.1s
 => => transferring dockerfile: 3.55kB                                                                                                                                                                              0.0s
 => [internal] load metadata for public.ecr.aws/ubuntu/ubuntu:22.04                                                                                                                                                 0.5s
 => [internal] load .dockerignore                                                                                                                                                                                   0.1s
 => => transferring context: 50B                                                                                                                                                                                    0.0s
 => [internal] load build context                                                                                                                                                                                   0.1s
 => => transferring context: 4.64kB                                                                                                                                                                                 0.0s
 => [ 1/19] FROM public.ecr.aws/ubuntu/ubuntu:22.04@sha256:b2fd7c7dee18f2ce9023550702af6408d322a278800ed07829c6dc94b82960b0                                                                                         0.0s
 => CACHED [ 2/19] WORKDIR /agent-go                                                                                                                                                                                0.0s
 => CACHED [ 3/19] RUN apt-get update -y     && apt-get install -y software-properties-common     && apt update -y     && add-apt-repository universe     && apt-get install -y build-essential         ca-certifi  0.0s
 => CACHED [ 4/19] RUN wget -O - https://apt.llvm.org/llvm.sh | bash -s 17     && echo "export CXX=clang++-17" >> /root/.bashrc     && echo "export CC=clang-17" >> /root/.bashrc                                   0.0s
 => CACHED [ 5/19] COPY go.mod /tmp/go.mod                                                                                                                                                                          0.0s
 => CACHED [ 6/19] RUN GO_VERSION=$(grep -oPm1 '^go \K([[:digit:].]+)' /tmp/go.mod) &&     GOARCH=$(uname -m) && if [ "$GOARCH" = "x86_64" ]; then GOARCH=amd64; elif [ "$GOARCH" = "aarch64" ]; then GOARCH=arm64  0.0s
 => CACHED [ 7/19] RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0                                                                                                                              0.0s
 => CACHED [ 8/19] RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0                                                                                                                              0.0s
 => CACHED [ 9/19] RUN go install github.com/jcchavezs/porto/cmd/porto@v0.6.0                                                                                                                                       0.0s
 => CACHED [10/19] RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4                                                                                                                       0.0s
 => CACHED [11/19] RUN                                                                                  PB_URL="https://github.com/protocolbuffers/protobuf/releases/download/v24.4/";     PB_FILE="protoc-24.4-li  0.0s
 => CACHED [12/19] RUN echo 'export PATH="$PATH"' >> /etc/profile                                                                                                                                                   0.0s
 => CACHED [13/19] RUN mkdir -p /usr/local/cargo /usr/local/rustup                                                                                                                                                  0.0s
 => CACHED [14/19] RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.77                                                                           0.0s
 => CACHED [15/19] RUN echo 'export PATH="/usr/local/cargo/bin:$PATH"' >> /etc/profile         && echo 'export CARGO_HOME="/usr/local/cargo"' >> /etc/profile          && echo 'export RUSTUP_HOME="/usr/local/rus  0.0s
 => CACHED [16/19] RUN chmod -R a+w /usr/local/rustup          && chmod -R a+w /usr/local/cargo                                                                                                                     0.0s
 => CACHED [17/19] WORKDIR /agent                                                                                                                                                                                   0.0s
 => CACHED [18/19] COPY docker-image/entrypoint.sh /entrypoint.sh                                                                                                                                                   0.0s
 => CACHED [19/19] RUN chmod +x /entrypoint.sh                                                                                                                                                                      0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:c28983cd017331055454d0c7b4c837151206f25d4a428b93fa6142494e4bae83                                                                                                                        0.0s
 => => naming to docker.io/library/profiling-agent                                                                                                                                                                  0.0s
```

```
root@BUbu1:~/instana-ebpf/opentelemetry-ebpf-profiler# make agent
docker run -v "$PWD":/agent -v /:/usr/sysroot -it --rm --user 0:0 profiling-agent \
   "make COMPILER_TARGET=x86_64-redhat-linux TARGET_ARCH=amd64 VERSION=v0.0.0 REVISION=adapt_dockerfile-69e0bdfc BUILD_TIMESTAMP=1742399921"
GOARCH=amd64 go generate ./...
rustup target add x86_64-unknown-linux-musl
info: downloading component 'rust-std' for 'x86_64-unknown-linux-musl'
go: not generating in packages in dependency modules
info: installing component 'rust-std' for 'x86_64-unknown-linux-musl'
(cd support && ./generate.sh)
types_gen.go
make  -C support/ebpf
make[1]: Entering directory '/agent/support/ebpf'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/agent/support/ebpf'
 33.0 MiB /  33.0 MiB (100 %)   7.4 MiB/s in  4s         
cargo build --lib --release --target x86_64-unknown-linux-musl
    Updating crates.io index
  Downloaded bytes v1.6.0
  Downloaded adler v1.0.2
  Downloaded intervaltree v0.2.7
  Downloaded block-buffer v0.10.4
  Downloaded equivalent v1.0.1
  Downloaded cpufeatures v0.2.12
  Downloaded thiserror v1.0.61
  Downloaded zstd-safe v7.1.0
  Downloaded tempfile v3.10.1
  Downloaded zstd v0.13.1
  Downloaded typenum v1.17.0
  Downloaded prost-types v0.12.6
  Downloaded prettyplease v0.2.22
  Downloaded unicode-ident v1.0.12
  Downloaded miniz_oxide v0.7.3
  Downloaded flate2 v1.0.30
  Downloaded memchr v2.7.2
  Downloaded hashbrown v0.14.5
  Downloaded indexmap v2.5.0
  Downloaded itertools v0.12.1
  Downloaded aho-corasick v1.1.3
  Downloaded cpp_demangle v0.4.3
  Downloaded base64 v0.22.1
  Downloaded regex v1.10.6
  Downloaded syn v2.0.77
  Downloaded regex-syntax v0.8.4
  Downloaded rustix v0.38.34
  Downloaded object v0.36.0
  Downloaded gimli v0.30.0
  Downloaded regex-automata v0.4.7
  Downloaded zstd-sys v2.0.10+zstd.1.5.6
  Downloaded zydis v4.1.1
  Downloaded linux-raw-sys v0.4.14
  Downloaded petgraph v0.6.5
  Downloaded libc v0.2.155
  Downloaded prost-build v0.12.6
  Downloaded proc-macro2 v1.0.84
  Downloaded log v0.4.21
  Downloaded smallvec v1.13.2
  Downloaded sha2 v0.10.8
  Downloaded rustc-demangle v0.1.24
  Downloaded quote v1.0.36
  Downloaded crypto-common v0.1.6
  Downloaded cc v1.0.98
  Downloaded bitflags v2.5.0
  Downloaded once_cell v1.19.0
  Downloaded memmap2 v0.9.4
  Downloaded lru v0.12.3
  Downloaded jobserver v0.1.31
  Downloaded crc32fast v1.4.2
  Downloaded version_check v0.9.4
  Downloaded thiserror-impl v1.0.61
  Downloaded stable_deref_trait v1.2.0
  Downloaded prost-derive v0.12.6
  Downloaded prost v0.12.6
  Downloaded heck v0.5.0
  Downloaded generic-array v0.14.7
  Downloaded fastrand v2.1.0
  Downloaded errno v0.3.9
  Downloaded either v1.12.0
  Downloaded digest v0.10.7
  Downloaded cfg-if v1.0.0
  Downloaded pkg-config v0.3.30
  Downloaded multimap v0.10.0
  Downloaded fixedbitset v0.4.2
  Downloaded fallible-iterator v0.3.0
  Downloaded cmake v0.1.50
  Downloaded anyhow v1.0.86
  Downloaded 68 crates (9.5 MB) in 1.39s (largest was `linux-raw-sys` at 1.8 MB)
warning: dropping unsupported crate type `cdylib` for target `x86_64-unknown-linux-musl`

warning: `symblib-capi` (lib) generated 1 warning
    Finished release [optimized] target(s) in 2.53s
go build -buildvcs=false -ldflags="-X go.opentelemetry.io/ebpf-profiler/vc.version=v0.0.0 -X go.opentelemetry.io/ebpf-profiler/vc.revision=adapt_dockerfile-69e0bdfc -X go.opentelemetry.io/ebpf-profiler/vc.buildTimestamp=1742399921 \"-extldflags=--sysroot=/usr/sysroot --target=x86_64-redhat-linux\"" -tags osusergo,netgo
root@BUbu1:~/instana-ebpf/opentelemetry-ebpf-profiler# 
```