### PR TITLE
INSTA-80880 - Update golang to v1.23.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/ebpf-profiler
 
-go 1.22.2
+go 1.23.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.5


### PR DESCRIPTION
What:

- Update golang to 1.23.12

Why:

- To resolve security CVEs in the current v1.22
- JIRA: https://jsw.ibm.com/browse/INSTA-79467

Testing:
- Ran end-to-end tests with Instana agent and backend